### PR TITLE
Remove support for cflinuxfs3 stack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -11,6 +11,3 @@ api = "0.4"
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
-
-[[stacks]]
-  id = "org.cloudfoundry.stacks.cflinuxfs3"


### PR DESCRIPTION
No evidence of this stack being really used
Paketo project do not publish builders for this stack anymore.