### PR TITLE
Explictly request npm at launch

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -3,4 +3,5 @@ package npmstart
 const (
 	Node        = "node"
 	NodeModules = "node_modules"
+	Npm         = "npm"
 )

--- a/detect.go
+++ b/detect.go
@@ -38,6 +38,12 @@ func Detect(projectPathParser PathParser) packit.DetectFunc {
 						},
 					},
 					{
+						Name: Npm,
+						Metadata: map[string]interface{}{
+							"launch": true,
+						},
+					},
+					{
 						Name: NodeModules,
 						Metadata: map[string]interface{}{
 							"launch": true,

--- a/detect_test.go
+++ b/detect_test.go
@@ -58,6 +58,12 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 					{
+						Name: "npm",
+						Metadata: map[string]interface{}{
+							"launch": true,
+						},
+					},
+					{
 						Name: "node_modules",
 						Metadata: map[string]interface{}{
 							"launch": true,


### PR DESCRIPTION
This change is mostly cosmetic as node-engine buildpack provides both
node and npm when node is requested.
https://github.com/paketo-buildpacks/node-engine/blob/v0.8.0/README.md

This also makes the API consistent with the changes introduced in
https://github.com/paketo-buildpacks/yarn-start/pull/143 to
yarn-install.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
