### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/build.go
+++ b/build.go
@@ -71,6 +71,7 @@ func Build(pathParser PathParser, logger scribe.Logger) packit.BuildFunc {
 					{
 						Type:    "web",
 						Command: command,
+						Default: true,
 					},
 				},
 			},

--- a/build_test.go
+++ b/build_test.go
@@ -2,7 +2,6 @@ package npmstart_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,23 +30,23 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		layersDir, err = ioutil.TempDir("", "layers")
+		layersDir, err = os.MkdirTemp("", "layers")
 		Expect(err).NotTo(HaveOccurred())
 
-		cnbDir, err = ioutil.TempDir("", "cnb")
+		cnbDir, err = os.MkdirTemp("", "cnb")
 		Expect(err).NotTo(HaveOccurred())
 
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(os.Mkdir(filepath.Join(workingDir, "some-project-dir"), os.ModePerm)).To(Succeed())
-		err = ioutil.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+		err = os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
 			"scripts": {
 				"prestart": "some-prestart-command",
 				"start": "some-start-command",
 				"poststart": "some-poststart-command"
 			}
-		}`), 0644)
+		}`), 0600)
 		Expect(err).NotTo(HaveOccurred())
 
 		buffer = bytes.NewBuffer(nil)
@@ -90,6 +89,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					{
 						Type:    "web",
 						Command: "cd some-project-dir && some-prestart-command && some-start-command && some-poststart-command",
+						Default: true,
 					},
 				},
 			},
@@ -101,12 +101,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when there is no prestart script", func() {
 		it.Before(func() {
-			err := ioutil.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+			err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
 				"scripts": {
 					"start": "some-start-command",
 					"poststart": "some-poststart-command"
 				}
-			}`), 0644)
+			}`), 0600)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -135,6 +135,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: "cd some-project-dir && some-start-command && some-poststart-command",
+							Default: true,
 						},
 					},
 				},
@@ -144,12 +145,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when there is no poststart script", func() {
 		it.Before(func() {
-			err := ioutil.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+			err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
 				"scripts": {
 					"prestart": "some-prestart-command",
 					"start": "some-start-command"
 				}
-			}`), 0644)
+			}`), 0600)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -178,6 +179,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: "cd some-project-dir && some-prestart-command && some-start-command",
+							Default: true,
 						},
 					},
 				},
@@ -187,12 +189,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when there is no start script", func() {
 		it.Before(func() {
-			err := ioutil.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+			err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
 				"scripts": {
 					"prestart": "some-prestart-command",
 					"poststart": "some-poststart-command"
 				}
-			}`), 0644)
+			}`), 0600)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -221,6 +223,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: "cd some-project-dir && some-prestart-command && node server.js && some-poststart-command",
+							Default: true,
 						},
 					},
 				},
@@ -231,13 +234,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	context("when the project-path env var is not set", func() {
 		it.Before(func() {
 			pathParser.GetCall.Returns.ProjectPath = ""
-			err := ioutil.WriteFile(filepath.Join(workingDir, "package.json"), []byte(`{
+			err := os.WriteFile(filepath.Join(workingDir, "package.json"), []byte(`{
 			"scripts": {
 				"prestart": "some-prestart-command",
 				"start": "some-start-command",
 				"poststart": "some-poststart-command"
 			}
-		}`), 0644)
+		}`), 0600)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -270,6 +273,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: "some-prestart-command && some-start-command && some-poststart-command",
+							Default: true,
 						},
 					},
 				},
@@ -303,7 +307,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		context("when the package.json is malformed", func() {
 			it.Before(func() {
-				Expect(ioutil.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte("%%%"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte("%%%"), 0600)).To(Succeed())
 			})
 
 			it("returns an error", func() {

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/npm-start"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
