### PR TITLE
Use start script to not not rely on `bash` being available on run image

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -5,3 +5,9 @@ const (
 	NodeModules = "node_modules"
 	Npm         = "npm"
 )
+
+const StartupScript = `trap 'kill -TERM $CPID' TERM
+trap 'kill -INT $CPID' INT
+( %s ) &
+CPID="$!"
+wait $CPID`

--- a/constants.go
+++ b/constants.go
@@ -10,4 +10,7 @@ const StartupScript = `trap 'kill -TERM $CPID' TERM
 trap 'kill -INT $CPID' INT
 ( %s ) &
 CPID="$!"
-wait $CPID`
+wait $CPID
+trap - TERM INT
+wait $CPID
+`

--- a/integration/app_with_start_cmd_test.go
+++ b/integration/app_with_start_cmd_test.go
@@ -89,7 +89,7 @@ func testAppWithStartCmd(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Assigning launch processes:",
-				`    web (default): bash -c echo "prestart" && echo "start" && node server.js && echo "poststart"`,
+				ContainSubstring("web (default): sh /workspace/start.sh"),
 			))
 
 			cLogs := func() fmt.Stringer {

--- a/integration/graceful_shutdown_app_test.go
+++ b/integration/graceful_shutdown_app_test.go
@@ -91,10 +91,10 @@ func testGracefulShutdown(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(dockerStop(container.ID)).NotTo(HaveOccurred())
 
-			cLogs := func() fmt.Stringer {
+			cLogs := func() string {
 				containerLogs, err := docker.Container.Logs.Execute(container.ID)
 				Expect(err).NotTo(HaveOccurred())
-				return containerLogs
+				return containerLogs.String()
 			}
 
 			Eventually(cLogs).Should(ContainSubstring("echo from SIGTERM handler"))

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -71,7 +71,7 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Assigning launch processes:",
-				`    web (default): bash -c cd /workspace/server && echo "prestart" && echo "start" && node server.js && echo "poststart"`,
+				ContainSubstring("web (default): sh /workspace/server/start.sh"),
 				"",
 			))
 
@@ -129,9 +129,8 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 					"  Assigning launch processes:",
-
-					`    web (default): watchexec --restart --shell none --watch /workspace/server --ignore /workspace/server/package.json --ignore /workspace/server/package-lock.json --ignore /workspace/server/node_modules -- bash -c cd /workspace/server && echo "prestart" && echo "start" && node server.js && echo "poststart"`,
-					`    no-reload:     bash -c cd /workspace/server && echo "prestart" && echo "start" && node server.js && echo "poststart"`,
+					ContainSubstring("web (default): watchexec --restart --shell none --watch /workspace/server --ignore /workspace/server/package.json --ignore /workspace/server/package-lock.json --ignore /workspace/server/node_modules -- sh /workspace/server/start.sh"),
+					ContainSubstring("no-reload:     sh /workspace/server/start.sh"),
 					"",
 				))
 

--- a/integration/testdata/graceful_shutdown_app/server.js
+++ b/integration/testdata/graceful_shutdown_app/server.js
@@ -1,5 +1,6 @@
 const http = require('http');
 const leftpad = require('leftpad');
+const { syncBuiltinESMExports } = require('module');
 
 const port = process.env.PORT || 8080;
 
@@ -9,7 +10,7 @@ const server = http.createServer((request, response) => {
 
 process.once('SIGTERM', function (code) {
       console.log('echo from SIGTERM handler');
-      server.close();
+      server.close(() => {process.exit()});
 });
 
 server.listen(port, (err) => {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Currently, the buildpack uses `bash` to start the start command. This PR introduces a small start script with is generated and allows the usage of run images with "only" `sh` being present.

## Use Cases
<!-- An explanation of the use cases your change enables -->

To run a small `nodejs` application, the `base` stack is needed and therefor a `bash` is always present. But for small `nodejs`, it would be possible to reduce the run image drastically. With that change, even no `bash` is needed, but "only" a `sh`. This would result in smaller application images and a smaller CVE footprint.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
