### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paketo Buildpack for NPM Start Cloud Native
+# Paketo Buildpack for NPM Start
 
 ## `gcr.io/paketo-buildpacks/npm-start`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paketo NPM Start Cloud Native Buildpack
+# Paketo Buildpack for NPM Start Cloud Native
 
 ## `gcr.io/paketo-buildpacks/npm-start`
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.7"
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/npm-start"
   id = "paketo-buildpacks/npm-start"
-  name = "Paketo NPM Start Buildpack"
+  name = "Paketo Buildpack for NPM Start"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
Renames 'Paketo NPM Start Buildpack' to 'Paketo Buildpack for NPM Start'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
