### PR TITLE
Resolves start script reproducibility issue

### DIFF
--- a/build.go
+++ b/build.go
@@ -109,19 +109,11 @@ func createStartupScript(script, projectPath, workingDir string) (string, error)
 		targetDir = projectPath
 	}
 
-	f, err := os.CreateTemp(targetDir, "start.sh")
-	if err != nil {
-		return "", err
-	}
-	err = f.Chmod(0744)
-	if err != nil {
-		return "", err
-	}
-
-	_, err = f.WriteString(script)
+	path := filepath.Join(targetDir, "start.sh")
+	err := os.WriteFile(path, []byte(script), 0644)
 	if err != nil {
 		return "", err
 	}
 
-	return f.Name(), nil
+	return path, nil
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -86,6 +86,7 @@ func TestIntegration(t *testing.T) {
 	suite := spec.New("Integration", spec.Parallel(), spec.Report(report.Terminal{}))
 	suite("GracefulShutdown", testGracefulShutdown)
 	suite("ProjectPath", testProjectPath)
+	suite("ReproducibleBuilds", testReproducibleBuilds)
 	suite("StartCommand", testAppWithStartCmd)
 	suite.Run(t)
 }

--- a/integration/reproducible_builds_test.go
+++ b/integration/reproducible_builds_test.go
@@ -1,0 +1,75 @@
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testReproducibleBuilds(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	context("when rebuilding an image with pack", func() {
+		var (
+			image occam.Image
+
+			name   string
+			source string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "app_with_start_cmd"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it("creates an identical image from identical inputs", func() {
+			build := pack.WithNoColor().Build.
+				WithBuildpacks(
+					settings.Buildpacks.NodeEngine.Online,
+					settings.Buildpacks.NPMInstall.Online,
+					settings.Buildpacks.NPMStart.Online,
+				).
+				WithPullPolicy("never")
+
+			var err error
+			image, _, err = build.Execute(name, source)
+			Expect(err).NotTo(HaveOccurred())
+
+			firstID := image.ID
+
+			// Delete the first image
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+
+			image, _, err = build.Execute(name, source)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(image.ID).To(Equal(firstID))
+		})
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
PR #224 has caused some downstream failures in the Node.js language family integration suite. Specifically, the tests that assert build reproducibility are failing: https://github.com/paketo-buildpacks/nodejs/runs/8161160806?check_suite_focus=true#step:5:201.

## Use Cases
<!-- An explanation of the use cases your change enables -->
* Ensures the script isn't created with a random name
* Adds a test to assert build reproducibility

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
