### PR TITLE
Reverting the change of fetching watchexec from registry instead of building it. 

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -6,5 +6,5 @@
   "ubi-nodejs-extension": "github.com/paketo-community/ubi-nodejs-extension",
   "node-engine": "github.com/paketo-buildpacks/node-engine",
   "npm-install": "github.com/paketo-buildpacks/npm-install",
-  "watchexec": "index.docker.io/paketobuildpacks/watchexec"
+  "watchexec": "github.com/paketo-buildpacks/watchexec"
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR reverts the change of this PR https://github.com/paketo-buildpacks/npm-start/pull/477 which was fetching watchexec from the registry instead of building it. This change had to be made in the past as pack CLI could not properly support building buildpacks with `--target` flag. On later versions of the `pack`, this bug has been fixed, as seen on the changelog https://github.com/buildpacks/pack/releases/tag/v0.34.0 , so now watchexec can be properly builded.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
