### PR TITLE
Upgrading occam

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/onsi/gomega v1.36.2
 	github.com/paketo-buildpacks/libnodejs v0.4.0
 	github.com/paketo-buildpacks/libreload-packit v0.0.1
-	github.com/paketo-buildpacks/occam v0.20.0
+	github.com/paketo-buildpacks/occam v0.23.0
 	github.com/paketo-buildpacks/packit/v2 v2.16.0
 	github.com/sclevine/spec v1.4.0
 )
@@ -16,7 +16,7 @@ require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
-	github.com/ForestEckhardt/freezer v0.1.0 // indirect
+	github.com/ForestEckhardt/freezer v0.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -714,8 +714,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
-github.com/ForestEckhardt/freezer v0.1.0 h1:1Av1G+uJTmhhJGuV8MkVLdiEH8ljuiBaV+Cgy30QbRE=
-github.com/ForestEckhardt/freezer v0.1.0/go.mod h1:fQApI/B3u/Pu6DD4rxmzBJQUBDc9EDu7ieqM6l4JvZA=
+github.com/ForestEckhardt/freezer v0.1.1 h1:ELpuDAAq2oLRXfddigV2TWbFloXu+mYkHjiHe8E9Ljk=
+github.com/ForestEckhardt/freezer v0.1.1/go.mod h1:fQApI/B3u/Pu6DD4rxmzBJQUBDc9EDu7ieqM6l4JvZA=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20191009163259-e802c2cb94ae/go.mod h1:mjwGPas4yKduTyubHvD1Atl9r1rUq8DfVy+gkVvZ+oo=
 github.com/GoogleCloudPlatform/cloudsql-proxy v1.27.0/go.mod h1:bn9iHmAjogMoIPkqBGyJ9R1m9cXGCjBE/cuhBs3oEsQ=
 github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible/go.mod h1:BB1eHdMLYEFuFdBlRMb0N7YGVdM5s6Pt0njxgvfbGGs=
@@ -2566,8 +2566,8 @@ github.com/paketo-buildpacks/libnodejs v0.4.0 h1:a1cPKgseviKOrcf6W5M62CM3u2Yh0XH
 github.com/paketo-buildpacks/libnodejs v0.4.0/go.mod h1:V8bTCbjjpthcdrDK2g2KL7c0mHQeZJAfN+hQtPpmGuQ=
 github.com/paketo-buildpacks/libreload-packit v0.0.1 h1:K1HhNAqBSzRpefwGOcvdchZwyeNTgNJL9SC7V4paYt8=
 github.com/paketo-buildpacks/libreload-packit v0.0.1/go.mod h1:ZWE3U94Z18yJk8Pc1mP852l9phQsrsZ+An2U98g0rWw=
-github.com/paketo-buildpacks/occam v0.20.0 h1:R9lFiYBy8xVJLa09+3GV2R9jtPB/4yi4CcscqFTCgAA=
-github.com/paketo-buildpacks/occam v0.20.0/go.mod h1:PyG1KPqnnLweufXS1yGPcAKccUs3oqPFZUjIFO9FOZ0=
+github.com/paketo-buildpacks/occam v0.23.0 h1:zAZC0evlqHE1P7FJ+nqvl+uE5Xh8yb79x5bTdzbSeCA=
+github.com/paketo-buildpacks/occam v0.23.0/go.mod h1:K3Xc13S07hx1+2JEpPq4hIz5B5jEOwqubpazVs187H0=
 github.com/paketo-buildpacks/packit/v2 v2.6.1/go.mod h1:iBArWOfC5xZQF01o+zwnVKS+/hUBuFG+O1jCvzqBujs=
 github.com/paketo-buildpacks/packit/v2 v2.16.0 h1:zy5sszT/awIgpT4NioQolai/0H3ANIXlGW9wCbmwzrQ=
 github.com/paketo-buildpacks/packit/v2 v2.16.0/go.mod h1:LchgmOIDCXSDovrpoyP1J/yQEJq0Ely/vGCdiTp0vtA=


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Upgrades occam and freezer to the latest version. 
In the past, occam was not able to identify the assets based on the architecture and always by default was downloading the amd64 version. Similarly freezer was not able to identify the where to store the non amd64 artifacts. With the latest changes, occam and freezer can work together and download the proper artifacts based on the architecture that each buildpack support during the integration testing. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
