### PR TITLE
Introducing BP_LAUNCH_WITH_TINI env variable for enabling running on tiny run images

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ $ ./scripts/package.sh --version <version-number>
 
 This will create a `buildpackage.cnb` file under the `build` directory which you
 can use to build your app as follows:
+
 ```
 pack build <app-name> -p <path-to-app> -b <path/to/node-engine.cnb> -b \
 <path/to/npm-install.cnb> -b build/buildpackage.cnb
@@ -67,11 +68,13 @@ file](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor
 ## Run Tests
 
 To run all unit tests, run:
+
 ```
 ./scripts/unit.sh
 ```
 
 To run all integration tests, run:
+
 ```
 /scripts/integration.sh
 ```
@@ -82,6 +85,23 @@ You can add signal handlers in your app to support graceful shutdown and
 program interrupts. If running a node server is the start command, the
 buildpack runs the node server as the init process, and thus it ignores any
 signal with the default action. As a result, the process will not terminate on
-`SIGINT` or `SIGTERM` unless it is coded to do so. You can also use docker's
-`--init` flag to wrap your node process with an init system that will properly
-handle signals.
+`SIGINT` or `SIGTERM` unless it is coded to do so.
+
+By default, this buildpack writes a small startup script that forwards
+signals to the application process.
+
+You can also use [tini](https://github.com/krallin/tini) for signal forwarding
+by setting `BP_LAUNCH_WITH_TINI=true` at build time. The tini buildpack must be
+available in the builder order before this buildpack, otherwise detection
+fails. This is useful for tiny run images that have no shell, and therefore no
+shell-based signal forwarding.
+
+When tini is enabled:
+
+- The launch process is `tini -g -- <start-args>`, where `<start-args>` is the
+  `scripts.start` value from `package.json` split on whitespace. For example,
+  `"start": "node server.js"` becomes `tini -g -- node server.js`.
+- `prestart` and `poststart` are skipped (with a build-time warning), because
+  tini runs a single command without a shell.
+- Shell syntax in `scripts.start` (for example `&&`, pipes, or quotes) is not
+  interpreted; the value is split on whitespace only.

--- a/README.md
+++ b/README.md
@@ -105,3 +105,5 @@ When tini is enabled:
   tini runs a single command without a shell.
 - Shell syntax in `scripts.start` (for example `&&`, pipes, or quotes) is not
   interpreted; the value is split on whitespace only.
+- `BP_NODE_PROJECT_PATH` is not supported with tini and will cause the build to
+  fail.

--- a/build.go
+++ b/build.go
@@ -27,49 +27,79 @@ func Build(logger scribe.Emitter, reloader Reloader) packit.BuildFunc {
 			return packit.BuildResult{}, err
 		}
 
-		command := "sh"
-		arg := concatenateNpmScripts(pkg)
+		var originalProcess packit.Process
 
-		// Ideally we would like the lifecycle to support setting a custom working
-		// directory to run the launch process.  Until that happens we will cd in.
-
-		if projectPath != context.WorkingDir {
-			arg = fmt.Sprintf("cd %s && %s", projectPath, arg)
-		}
-
-		/*
-			Ubuntu uses Dash as the default shell, while UBI uses Bash.
-			The version of Bash on the current UBI images does not properly handle
-			the signal handling logic added in the script. Running the command using bash -c
-			and escaping the quotes changes the behavior to match that of of running with Dash.
-			This issue is fixed in more recent versions of Bash (>=5.x), however until UBI and Ubuntu
-			begin using this version, the following workaround is necesary.
-		*/
-		etcOsReleaseFileContent, err := os.ReadFile(filepath.Join("/etc/os-release"))
-		if err == nil {
-			re := regexp.MustCompile(`ID=(rhel|"rhel")`)
-
-			match := re.FindStringSubmatch(string(etcOsReleaseFileContent))
-			if match != nil {
-				arg = fmt.Sprintf("bash -c \"%s\"", strings.ReplaceAll(arg, `"`, `\"`))
-			}
-		}
-
-		script, err := createStartupScript(fmt.Sprintf(StartupScript, arg), projectPath, context.WorkingDir)
+		shouldLaunchWithTini, err := libnodejs.ShouldLaunchWithTini()
 		if err != nil {
 			return packit.BuildResult{}, err
 		}
 
-		args := []string{script}
-		originalProcess := packit.Process{
-			Type:    "web",
-			Command: command,
-			Args:    args,
-			Default: true,
-			Direct:  true,
-		}
-		var processes []packit.Process
+		if shouldLaunchWithTini {
+			startParts := strings.Fields(pkg.Scripts.Start)
+			if len(startParts) == 0 {
+				return packit.BuildResult{}, fmt.Errorf("failed to parse start script %q", pkg.Scripts.Start)
+			}
 
+			originalProcess = packit.Process{
+				Type:    "web",
+				Command: Tini,
+				Args:    append([]string{"-g", "--"}, startParts...),
+				Default: true,
+				Direct:  true,
+			}
+			if projectPath != context.WorkingDir {
+				originalProcess.WorkingDirectory = projectPath
+			}
+
+			logger.Process("Using tini for process launching")
+			if pkg.Scripts.PreStart != "" || pkg.Scripts.PostStart != "" {
+				logger.Subprocess("Warning: skipping prestart and/or poststart scripts because BP_LAUNCH_WITH_TINI is enabled")
+			}
+		} else {
+			command := "sh"
+			arg := concatenateNpmScripts(pkg)
+
+			// Ideally we would like the lifecycle to support setting a custom working
+			// directory to run the launch process.  Until that happens we will cd in.
+
+			if projectPath != context.WorkingDir {
+				arg = fmt.Sprintf("cd %s && %s", projectPath, arg)
+			}
+
+			/*
+				Ubuntu uses Dash as the default shell, while UBI uses Bash.
+				The version of Bash on the current UBI images does not properly handle
+				the signal handling logic added in the script. Running the command using bash -c
+				and escaping the quotes changes the behavior to match that of of running with Dash.
+				This issue is fixed in more recent versions of Bash (>=5.x), however until UBI and Ubuntu
+				begin using this version, the following workaround is necesary.
+			*/
+			etcOsReleaseFileContent, err := os.ReadFile(filepath.Join("/etc/os-release"))
+			if err == nil {
+				re := regexp.MustCompile(`ID=(rhel|"rhel")`)
+
+				match := re.FindStringSubmatch(string(etcOsReleaseFileContent))
+				if match != nil {
+					arg = fmt.Sprintf("bash -c \"%s\"", strings.ReplaceAll(arg, `"`, `\"`))
+				}
+			}
+
+			script, err := createStartupScript(fmt.Sprintf(StartupScript, arg), projectPath, context.WorkingDir)
+			if err != nil {
+				return packit.BuildResult{}, err
+			}
+
+			args := []string{script}
+			originalProcess = packit.Process{
+				Type:    "web",
+				Command: command,
+				Args:    args,
+				Default: true,
+				Direct:  true,
+			}
+		}
+
+		var processes []packit.Process
 		if shouldEnableReload, err := reloader.ShouldEnableLiveReload(); err != nil {
 			return packit.BuildResult{}, err
 		} else if shouldEnableReload {

--- a/build.go
+++ b/build.go
@@ -28,15 +28,7 @@ func Build(logger scribe.Emitter, reloader Reloader) packit.BuildFunc {
 		}
 
 		command := "sh"
-		arg := fmt.Sprintf("%s $@", pkg.Scripts.Start)
-
-		if pkg.Scripts.PreStart != "" {
-			arg = fmt.Sprintf("%s && %s", pkg.Scripts.PreStart, arg)
-		}
-
-		if pkg.Scripts.PostStart != "" {
-			arg = fmt.Sprintf("%s && %s", arg, pkg.Scripts.PostStart)
-		}
+		arg := concatenateNpmScripts(pkg)
 
 		// Ideally we would like the lifecycle to support setting a custom working
 		// directory to run the launch process.  Until that happens we will cd in.
@@ -122,4 +114,18 @@ func createStartupScript(script, projectPath, workingDir string) (string, error)
 	}
 
 	return path, nil
+}
+
+func concatenateNpmScripts(pkg libnodejs.PackageJSON) string {
+	arg := fmt.Sprintf("%s $@", pkg.Scripts.Start)
+
+	if pkg.Scripts.PreStart != "" {
+		arg = fmt.Sprintf("%s && %s", pkg.Scripts.PreStart, arg)
+	}
+
+	if pkg.Scripts.PostStart != "" {
+		arg = fmt.Sprintf("%s && %s", arg, pkg.Scripts.PostStart)
+	}
+
+	return arg
 }

--- a/build.go
+++ b/build.go
@@ -35,6 +35,10 @@ func Build(logger scribe.Emitter, reloader Reloader) packit.BuildFunc {
 		}
 
 		if shouldLaunchWithTini {
+			if projectPath != context.WorkingDir {
+				return packit.BuildResult{}, fmt.Errorf("BP_LAUNCH_WITH_TINI does not support yet being used with BP_NODE_PROJECT_PATH")
+			}
+
 			startParts := strings.Fields(pkg.Scripts.Start)
 			if len(startParts) == 0 {
 				return packit.BuildResult{}, fmt.Errorf("failed to parse start script %q", pkg.Scripts.Start)
@@ -46,9 +50,6 @@ func Build(logger scribe.Emitter, reloader Reloader) packit.BuildFunc {
 				Args:    append([]string{"-g", "--"}, startParts...),
 				Default: true,
 				Direct:  true,
-			}
-			if projectPath != context.WorkingDir {
-				originalProcess.WorkingDirectory = projectPath
 			}
 
 			logger.Process("Using tini for process launching")

--- a/build_test.go
+++ b/build_test.go
@@ -95,9 +95,79 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}))
 
 		Expect(startScript).To(matchers.BeAFileWithSubstring("some-prestart-command && some-start-command $@ && some-poststart-command"))
+		Expect(startScript).To(matchers.BeAFileWithSubstring("trap 'kill -TERM $CPID' TERM"))
 
 		Expect(buffer.String()).To(ContainSubstring("Some Buildpack some-version"))
 		Expect(buffer.String()).To(ContainSubstring("Assigning launch processes:"))
+	})
+
+	context("when BP_LAUNCH_WITH_TINI is true", func() {
+		it.Before(func() {
+			t.Setenv("BP_LAUNCH_WITH_TINI", "true")
+			err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+				"scripts": {
+					"start": "node server.js"
+				}
+			}`), 0600)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it("uses tini with the start script contents", func() {
+			result, err := build(buildContext)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Launch.Processes).To(ConsistOf(packit.Process{
+				Type:             "web",
+				Command:          "tini",
+				Default:          true,
+				Direct:           true,
+				WorkingDirectory: filepath.Join(workingDir, "some-project-dir"),
+				Args:             []string{"-g", "--", "node", "server.js"},
+			}))
+
+			Expect(startScript).NotTo(BeAnExistingFile())
+			Expect(buffer.String()).To(ContainSubstring("Using tini for process launching"))
+		})
+
+		context("when prestart or poststart scripts are present", func() {
+			it.Before(func() {
+				err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+					"scripts": {
+						"prestart": "some-prestart-command",
+						"start": "node server.js",
+						"poststart": "some-poststart-command"
+					}
+				}`), 0600)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("warns and skips prestart and poststart", func() {
+				result, err := build(buildContext)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(result.Launch.Processes).To(ConsistOf(packit.Process{
+					Type:             "web",
+					Command:          "tini",
+					Default:          true,
+					Direct:           true,
+					WorkingDirectory: filepath.Join(workingDir, "some-project-dir"),
+					Args:             []string{"-g", "--", "node", "server.js"},
+				}))
+
+				Expect(buffer.String()).To(ContainSubstring("Warning: skipping prestart and/or poststart scripts because BP_LAUNCH_WITH_TINI is enabled"))
+			})
+		})
+	})
+
+	context("when BP_LAUNCH_WITH_TINI is malformed", func() {
+		it.Before(func() {
+			t.Setenv("BP_LAUNCH_WITH_TINI", "not-a-bool")
+		})
+
+		it("returns an error", func() {
+			_, err := build(buildContext)
+			Expect(err).To(MatchError(ContainSubstring("failed to parse BP_LAUNCH_WITH_TINI value not-a-bool")))
+		})
 	})
 
 	context("when live reload is enabled", func() {
@@ -144,6 +214,42 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(startScript).To(matchers.BeAFileWithSubstring("some-prestart-command && some-start-command $@ && some-poststart-command"))
 
+		})
+
+		context("when BP_LAUNCH_WITH_TINI is also true", func() {
+			it.Before(func() {
+				t.Setenv("BP_LAUNCH_WITH_TINI", "true")
+				err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+					"scripts": {
+						"start": "node server.js"
+					}
+				}`), 0600)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("wraps the tini process with watchexec", func() {
+				result, err := build(buildContext)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(reloader.TransformReloadableProcessesCall.Receives.OriginalProcess).To(Equal(packit.Process{
+					Type:             "web",
+					Command:          "tini",
+					Args:             []string{"-g", "--", "node", "server.js"},
+					Default:          true,
+					Direct:           true,
+					WorkingDirectory: filepath.Join(workingDir, "some-project-dir"),
+				}))
+
+				Expect(result.Launch.Processes).To(ConsistOf(packit.Process{
+					Type:    "web",
+					Command: "Reloadable",
+				}, packit.Process{
+					Type:    "no-reload",
+					Command: "NonReloadable",
+				}))
+
+				Expect(buffer.String()).To(ContainSubstring("Using tini for process launching"))
+			})
 		})
 	})
 

--- a/build_test.go
+++ b/build_test.go
@@ -104,7 +104,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	context("when BP_LAUNCH_WITH_TINI is true", func() {
 		it.Before(func() {
 			t.Setenv("BP_LAUNCH_WITH_TINI", "true")
-			err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+			t.Setenv("BP_NODE_PROJECT_PATH", "")
+			err := os.WriteFile(filepath.Join(workingDir, "package.json"), []byte(`{
 				"scripts": {
 					"start": "node server.js"
 				}
@@ -117,21 +118,20 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result.Launch.Processes).To(ConsistOf(packit.Process{
-				Type:             "web",
-				Command:          "tini",
-				Default:          true,
-				Direct:           true,
-				WorkingDirectory: filepath.Join(workingDir, "some-project-dir"),
-				Args:             []string{"-g", "--", "node", "server.js"},
+				Type:    "web",
+				Command: "tini",
+				Default: true,
+				Direct:  true,
+				Args:    []string{"-g", "--", "node", "server.js"},
 			}))
 
-			Expect(startScript).NotTo(BeAnExistingFile())
+			Expect(filepath.Join(workingDir, "start.sh")).NotTo(BeAnExistingFile())
 			Expect(buffer.String()).To(ContainSubstring("Using tini for process launching"))
 		})
 
 		context("when prestart or poststart scripts are present", func() {
 			it.Before(func() {
-				err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+				err := os.WriteFile(filepath.Join(workingDir, "package.json"), []byte(`{
 					"scripts": {
 						"prestart": "some-prestart-command",
 						"start": "node server.js",
@@ -146,15 +146,31 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(result.Launch.Processes).To(ConsistOf(packit.Process{
-					Type:             "web",
-					Command:          "tini",
-					Default:          true,
-					Direct:           true,
-					WorkingDirectory: filepath.Join(workingDir, "some-project-dir"),
-					Args:             []string{"-g", "--", "node", "server.js"},
+					Type:    "web",
+					Command: "tini",
+					Default: true,
+					Direct:  true,
+					Args:    []string{"-g", "--", "node", "server.js"},
 				}))
 
 				Expect(buffer.String()).To(ContainSubstring("Warning: skipping prestart and/or poststart scripts because BP_LAUNCH_WITH_TINI is enabled"))
+			})
+		})
+
+		context("when BP_NODE_PROJECT_PATH is set", func() {
+			it.Before(func() {
+				t.Setenv("BP_NODE_PROJECT_PATH", "some-project-dir")
+				err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+					"scripts": {
+						"start": "node server.js"
+					}
+				}`), 0600)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("returns an error", func() {
+				_, err := build(buildContext)
+				Expect(err).To(MatchError(ContainSubstring("BP_LAUNCH_WITH_TINI does not support yet being used with BP_NODE_PROJECT_PATH")))
 			})
 		})
 	})
@@ -219,7 +235,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		context("when BP_LAUNCH_WITH_TINI is also true", func() {
 			it.Before(func() {
 				t.Setenv("BP_LAUNCH_WITH_TINI", "true")
-				err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+				t.Setenv("BP_NODE_PROJECT_PATH", "")
+				err := os.WriteFile(filepath.Join(workingDir, "package.json"), []byte(`{
 					"scripts": {
 						"start": "node server.js"
 					}
@@ -232,12 +249,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(reloader.TransformReloadableProcessesCall.Receives.OriginalProcess).To(Equal(packit.Process{
-					Type:             "web",
-					Command:          "tini",
-					Args:             []string{"-g", "--", "node", "server.js"},
-					Default:          true,
-					Direct:           true,
-					WorkingDirectory: filepath.Join(workingDir, "some-project-dir"),
+					Type:    "web",
+					Command: "tini",
+					Args:    []string{"-g", "--", "node", "server.js"},
+					Default: true,
+					Direct:  true,
 				}))
 
 				Expect(result.Launch.Processes).To(ConsistOf(packit.Process{

--- a/constants.go
+++ b/constants.go
@@ -4,6 +4,7 @@ const (
 	Node        = "node"
 	NodeModules = "node_modules"
 	Npm         = "npm"
+	Tini        = "tini"
 )
 
 const StartupScript = `trap 'kill -TERM $CPID' TERM

--- a/detect.go
+++ b/detect.go
@@ -34,6 +34,11 @@ func Detect(reloader Reloader) packit.DetectFunc {
 			return packit.DetectResult{}, packit.Fail.WithMessage(NoStartScriptError)
 		}
 
+		shouldLaunchWithTini, err := libnodejs.ShouldLaunchWithTini()
+		if err != nil {
+			return packit.DetectResult{}, err
+		}
+
 		requirements := []packit.BuildPlanRequirement{
 			{
 				Name: Node,
@@ -41,19 +46,30 @@ func Detect(reloader Reloader) packit.DetectFunc {
 					"launch": true,
 				},
 			},
-			{
+		}
+
+		if shouldLaunchWithTini {
+			requirements = append(requirements, packit.BuildPlanRequirement{
+				Name: Tini,
+				Metadata: map[string]interface{}{
+					"launch": true,
+				},
+			})
+		} else {
+			requirements = append(requirements, packit.BuildPlanRequirement{
 				Name: Npm,
 				Metadata: map[string]interface{}{
 					"launch": true,
 				},
-			},
-			{
-				Name: NodeModules,
-				Metadata: map[string]interface{}{
-					"launch": true,
-				},
-			},
+			})
 		}
+
+		requirements = append(requirements, packit.BuildPlanRequirement{
+			Name: NodeModules,
+			Metadata: map[string]interface{}{
+				"launch": true,
+			},
+		})
 
 		if shouldReload, err := reloader.ShouldEnableLiveReload(); err != nil {
 			return packit.DetectResult{}, err

--- a/detect_test.go
+++ b/detect_test.go
@@ -113,6 +113,41 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				}))
 			})
 		})
+
+		context("when BP_LAUNCH_WITH_TINI is true", func() {
+			it.Before(func() {
+				t.Setenv("BP_LAUNCH_WITH_TINI", "true")
+			})
+
+			it("requires tini at launch and omits npm", func() {
+				result, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Plan).To(Equal(packit.BuildPlan{
+					Requires: []packit.BuildPlanRequirement{
+						{
+							Name: "node",
+							Metadata: map[string]interface{}{
+								"launch": true,
+							},
+						},
+						{
+							Name: "tini",
+							Metadata: map[string]interface{}{
+								"launch": true,
+							},
+						},
+						{
+							Name: "node_modules",
+							Metadata: map[string]interface{}{
+								"launch": true,
+							},
+						},
+					},
+				}))
+			})
+		})
 	})
 
 	context("when there is a package.json without a start script", func() {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/onsi/gomega v1.42.1
-	github.com/paketo-buildpacks/libnodejs v0.4.3
+	github.com/paketo-buildpacks/libnodejs v0.5.0
 	github.com/paketo-buildpacks/libreload-packit v0.0.1
 	github.com/paketo-buildpacks/occam v0.31.3
 	github.com/paketo-buildpacks/packit/v2 v2.25.5

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/paketo-buildpacks/freezer v0.2.3 h1:nkMNtRFxStXauh/IJdy+2Gc11tJNcfkg7q2LyluwnRM=
 github.com/paketo-buildpacks/freezer v0.2.3/go.mod h1:sVvsjcmT+ee5TTcTfQv0CcY8qtM6+XVdzp0CIvMDTwM=
-github.com/paketo-buildpacks/libnodejs v0.4.3 h1:jVIscdU8j8XhjnVkQw0q9uOwO+V/pI0b+riAeDMdR1Q=
-github.com/paketo-buildpacks/libnodejs v0.4.3/go.mod h1:aqEc7+NFTwxNqk0m8LTOSRYTL8DR1FPJh8NpscoRo6k=
+github.com/paketo-buildpacks/libnodejs v0.5.0 h1:sKg8J9Wp3oMyNAod8vEuRZuJrP2uOF8uYKSFU8JJ1sQ=
+github.com/paketo-buildpacks/libnodejs v0.5.0/go.mod h1:04zJPJVNCxNvLpljlYGi2755i6sIWlNh4Jm0/OmeDG4=
 github.com/paketo-buildpacks/libreload-packit v0.0.1 h1:K1HhNAqBSzRpefwGOcvdchZwyeNTgNJL9SC7V4paYt8=
 github.com/paketo-buildpacks/libreload-packit v0.0.1/go.mod h1:ZWE3U94Z18yJk8Pc1mP852l9phQsrsZ+An2U98g0rWw=
 github.com/paketo-buildpacks/occam v0.31.3 h1:4EhnaRVzWVHKIKC+XY3f2KQI2EaVJDUY3RmfIojiiQ8=

--- a/integration.json
+++ b/integration.json
@@ -10,5 +10,6 @@
   "ubi-nodejs-extension": "github.com/paketo-buildpacks/ubi-nodejs-extension",
   "node-engine": "github.com/paketo-buildpacks/node-engine",
   "npm-install": "github.com/paketo-buildpacks/npm-install",
-  "watchexec": "github.com/paketo-buildpacks/watchexec"
+  "watchexec": "github.com/paketo-buildpacks/watchexec",
+  "tini": "github.com/paketo-buildpacks/tini"
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -30,6 +30,9 @@ var settings struct {
 		Watchexec struct {
 			Online string
 		}
+		Tini struct {
+			Online string
+		}
 	}
 	Buildpack struct {
 		ID   string
@@ -39,6 +42,7 @@ var settings struct {
 		NodeEngine         string `json:"node-engine"`
 		NPMInstall         string `json:"npm-install"`
 		Watchexec          string `json:"watchexec"`
+		Tini               string `json:"tini"`
 		UbiNodejsExtension string `json:"ubi-nodejs-extension"`
 	}
 
@@ -98,6 +102,10 @@ func TestIntegration(t *testing.T) {
 		Execute(settings.Config.Watchexec)
 	Expect(err).ToNot(HaveOccurred())
 
+	settings.Buildpacks.Tini.Online, err = buildpackStore.Get.
+		Execute(settings.Config.Tini)
+	Expect(err).ToNot(HaveOccurred())
+
 	SetDefaultEventuallyTimeout(10 * time.Second)
 
 	suite := spec.New("Integration", spec.Parallel(), spec.Report(report.Terminal{}))
@@ -105,5 +113,6 @@ func TestIntegration(t *testing.T) {
 	suite("ProjectPath", testProjectPath)
 	suite("ReproducibleBuilds", testReproducibleBuilds)
 	suite("StartCommand", testAppWithStartCmd)
+	suite("Tini", testTini)
 	suite.Run(t)
 }

--- a/integration/testdata/app_with_start_cmd/package.json
+++ b/integration/testdata/app_with_start_cmd/package.json
@@ -19,6 +19,7 @@
     "start": "echo \"start\" && node hello.js",
     "start:dev": "echo \"start:dev\" && node hello.js",
     "start:arg": "echo \"start:arg\" && node",
+    "start:node": "node hello.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "version": "0.0.0"

--- a/integration/testdata/project_path_app/server/package.json
+++ b/integration/testdata/project_path_app/server/package.json
@@ -6,7 +6,6 @@
     "poststart": "echo \"poststart\"",
     "prestart": "echo \"prestart\"",
     "start": "echo \"start\" && node server.js",
-    "start:node": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/integration/testdata/project_path_app/server/package.json
+++ b/integration/testdata/project_path_app/server/package.json
@@ -6,6 +6,7 @@
     "poststart": "echo \"poststart\"",
     "prestart": "echo \"prestart\"",
     "start": "echo \"start\" && node server.js",
+    "start:node": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/integration/tini_test.go
+++ b/integration/tini_test.go
@@ -113,59 +113,5 @@ func testTini(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(ContainSubstring("hello world"))
 		})
-
-		it("uses tini with a custom project path", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "project_path_app"))
-			Expect(err).NotTo(HaveOccurred())
-
-			var logs fmt.Stringer
-			image, logs, err = pack.WithNoColor().Build.
-				WithExtensions(
-					settings.Extensions.UbiNodejsExtension.Online,
-				).
-				WithBuildpacks(
-					settings.Buildpacks.NodeEngine.Online,
-					settings.Buildpacks.NPMInstall.Online,
-					settings.Buildpacks.Tini.Online,
-					settings.Buildpacks.NPMStart.Online,
-				).
-				WithEnv(map[string]string{
-					"BP_LAUNCH_WITH_TINI":  "true",
-					"BP_NODE_PROJECT_PATH": "server",
-					"BP_NPM_START_SCRIPT":  "start:node",
-				}).
-				WithPullPolicy(pullPolicy).
-				Execute(name, source)
-			Expect(err).NotTo(HaveOccurred(), logs.String())
-
-			Expect(logs).To(ContainLines(
-				extenderBuildStr+"  Using tini for process launching",
-				extenderBuildStr+"    Warning: skipping prestart and/or poststart scripts because BP_LAUNCH_WITH_TINI is enabled",
-				extenderBuildStr+"  Assigning launch processes:",
-				extenderBuildStr+"    web (default): tini -g -- node server.js",
-			))
-
-			container, err = docker.Container.Run.
-				WithEnv(map[string]string{"PORT": "8080"}).
-				WithPublish("8080").
-				WithPublishAll().
-				Execute(image.ID)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(container).Should(BeAvailable())
-
-			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				Expect(response.Body.Close()).To(Succeed())
-			}()
-
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-			content, err := io.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(ContainSubstring("hello world"))
-		})
 	})
 }

--- a/integration/tini_test.go
+++ b/integration/tini_test.go
@@ -1,0 +1,171 @@
+package integration_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testTini(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+
+		pullPolicy       = "never"
+		extenderBuildStr = ""
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+
+		if settings.Extensions.UbiNodejsExtension.Online != "" {
+			pullPolicy = "always"
+			extenderBuildStr = "[extender (build)] "
+		}
+	})
+
+	context("when BP_LAUNCH_WITH_TINI=true", func() {
+		var (
+			image     occam.Image
+			container occam.Container
+
+			name   string
+			source string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it("uses tini to launch the start script", func() {
+			var err error
+			source, err = occam.Source(filepath.Join("testdata", "app_with_start_cmd"))
+			Expect(err).NotTo(HaveOccurred())
+
+			var logs fmt.Stringer
+			image, logs, err = pack.WithNoColor().Build.
+				WithExtensions(
+					settings.Extensions.UbiNodejsExtension.Online,
+				).
+				WithBuildpacks(
+					settings.Buildpacks.NodeEngine.Online,
+					settings.Buildpacks.NPMInstall.Online,
+					settings.Buildpacks.Tini.Online,
+					settings.Buildpacks.NPMStart.Online,
+				).
+				WithEnv(map[string]string{
+					"BP_LAUNCH_WITH_TINI": "true",
+					"BP_NPM_START_SCRIPT": "start:node",
+				}).
+				WithPullPolicy(pullPolicy).
+				Execute(name, source)
+			Expect(err).NotTo(HaveOccurred(), logs.String())
+
+			Expect(logs).To(ContainLines(
+				MatchRegexp(fmt.Sprintf(`%s%s \d+\.\d+\.\d+`, extenderBuildStr, settings.Buildpack.Name))))
+			Expect(logs).To(ContainLines(
+				extenderBuildStr+"  Using tini for process launching",
+				extenderBuildStr+"    Warning: skipping prestart and/or poststart scripts because BP_LAUNCH_WITH_TINI is enabled",
+				extenderBuildStr+"  Assigning launch processes:",
+				extenderBuildStr+"    web (default): tini -g -- node hello.js",
+			))
+
+			container, err = docker.Container.Run.
+				WithEnv(map[string]string{"PORT": "8080"}).
+				WithPublish("8080").
+				WithPublishAll().
+				Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(container).Should(BeAvailable())
+
+			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				Expect(response.Body.Close()).To(Succeed())
+			}()
+
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			content, err := io.ReadAll(response.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("hello world"))
+		})
+
+		it("uses tini with a custom project path", func() {
+			var err error
+			source, err = occam.Source(filepath.Join("testdata", "project_path_app"))
+			Expect(err).NotTo(HaveOccurred())
+
+			var logs fmt.Stringer
+			image, logs, err = pack.WithNoColor().Build.
+				WithExtensions(
+					settings.Extensions.UbiNodejsExtension.Online,
+				).
+				WithBuildpacks(
+					settings.Buildpacks.NodeEngine.Online,
+					settings.Buildpacks.NPMInstall.Online,
+					settings.Buildpacks.Tini.Online,
+					settings.Buildpacks.NPMStart.Online,
+				).
+				WithEnv(map[string]string{
+					"BP_LAUNCH_WITH_TINI":  "true",
+					"BP_NODE_PROJECT_PATH": "server",
+					"BP_NPM_START_SCRIPT":  "start:node",
+				}).
+				WithPullPolicy(pullPolicy).
+				Execute(name, source)
+			Expect(err).NotTo(HaveOccurred(), logs.String())
+
+			Expect(logs).To(ContainLines(
+				extenderBuildStr+"  Using tini for process launching",
+				extenderBuildStr+"    Warning: skipping prestart and/or poststart scripts because BP_LAUNCH_WITH_TINI is enabled",
+				extenderBuildStr+"  Assigning launch processes:",
+				extenderBuildStr+"    web (default): tini -g -- node server.js",
+			))
+
+			container, err = docker.Container.Run.
+				WithEnv(map[string]string{"PORT": "8080"}).
+				WithPublish("8080").
+				WithPublishAll().
+				Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(container).Should(BeAvailable())
+
+			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				Expect(response.Body.Close()).To(Succeed())
+			}()
+
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			content, err := io.ReadAll(response.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("hello world"))
+		})
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* Introduces and env variable called BP_LAUNCH_WITH_TINI env allowing using `tini` buildpack in order to launch the nodejs application

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
